### PR TITLE
Update for incompatible upstream changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ On an Adafruit Metro M4 Grand Central, capture a 40x30 image into a buffer:
 
     cam = OV7670(
         bus,
-        data0=board.PCC_D0,
+        data_pins=[board.PCC_D0, board.PCC_D1, board.PCC_D2, board.PCC_D3, board.PCC_D4, board.PCC_D5, board.PCC_D6, board.PCC_D7],
         clock=board.PCC_CLK,
         vsync=board.PCC_DEN1,
         href=board.PCC_DEN2,

--- a/adafruit_ov7670.py
+++ b/adafruit_ov7670.py
@@ -506,7 +506,7 @@ class OV7670:  # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         i2c_bus,
-        data0,
+        data_pins,
         clock,
         vsync,
         href,
@@ -519,7 +519,7 @@ class OV7670:  # pylint: disable=too-many-instance-attributes
         """
         Args:
             i2c_bus (busio.I2C): The I2C bus used to configure the OV7670
-            data0 (microcontroller.Pin): The first of 8 parallel data capture pins.
+            data_pins (List[microcontroller.Pin]): A list of 8 data pins, in order.
             clock (microcontroller.Pin): The pixel clock from the OV7670.
             vsync (microcontroller.Pin): The vsync signal from the OV7670.
             href (microcontroller.Pin): The href signal from the OV7670, \
@@ -581,7 +581,7 @@ class OV7670:  # pylint: disable=too-many-instance-attributes
         self._night = OV7670_NIGHT_MODE_OFF
 
         self._imagecapture = imagecapture.ParallelImageCapture(
-            data0=data0, clock=clock, vsync=vsync, href=href
+            data_pins=data_pins, clock=clock, vsync=vsync, href=href
         )
 
     def capture(self, buf):

--- a/examples/ov7670_displayio_gcm4_tftshield18.py
+++ b/examples/ov7670_displayio_gcm4_tftshield18.py
@@ -51,7 +51,16 @@ class OV7670_GrandCentral(OV7670):
             self,
             bus,
             mclk=board.PCC_XCLK,
-            data0=board.PCC_D0,
+            data_pins=[
+                board.PCC_D0,
+                board.PCC_D1,
+                board.PCC_D2,
+                board.PCC_D3,
+                board.PCC_D4,
+                board.PCC_D5,
+                board.PCC_D6,
+                board.PCC_D7,
+            ],
             clock=board.PCC_CLK,
             vsync=board.PCC_DEN1,
             href=board.PCC_DEN2,
@@ -84,7 +93,6 @@ tg = displayio.TileGrid(
 )
 g.append(tg)
 display.show(g)
-buf = memoryview(bitmap)
 
 t0 = time.monotonic_ns()
 display.auto_refresh = False

--- a/examples/ov7670_displayio_kaluga1_3_ili9341.py
+++ b/examples/ov7670_displayio_kaluga1_3_ili9341.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
+# SPDX-FileCopyrightText: Copyright (c) 2021 Jeff Epler for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+"""
+The Kaluga development kit comes in two versions (v1.2 and v1.3); this demo is
+tested on v1.3.  It probably won't work on v1.2 without modification.
+
+The v1.3 development kit's LCD can have one of two chips, the ili9341 or
+st7789.  Furthermore, there are at least 2 ILI9341 variants, one of which needs
+rotation=90!  This demo is for the ili9341.  If the display is garbled, try adding
+rotation=90, or try modifying it to use ST7799.
+
+The camera included with the Kaluga development kit is the incompatible OV2640,
+it won't work.
+
+The audio board must be mounted between the Kaluga and the LCD, it provides the
+I2C pull-ups(!)
+"""
+
+import time
+import board
+import busio
+import displayio
+from adafruit_ili9341 import ILI9341
+from adafruit_ov7670 import (  # pylint: disable=unused-import
+    OV7670,
+    OV7670_TEST_PATTERN_COLOR_BAR,
+    OV7670_SIZE_DIV2,
+    OV7670_NIGHT_MODE_2,
+)
+
+# Pylint is unable to see that the "size" property of OV7670_GrandCentral exists
+# pylint: disable=attribute-defined-outside-init
+
+# Release any resources currently in use for the displays
+displayio.release_displays()
+
+spi = busio.SPI(MOSI=board.LCD_MOSI, clock=board.LCD_CLK)
+display_bus = displayio.FourWire(
+    spi, command=board.LCD_D_C, chip_select=board.LCD_CS, reset=board.LCD_RST
+)
+display = ILI9341(display_bus, width=320, height=240)
+
+bus = busio.I2C(scl=board.CAMERA_SIOC, sda=board.CAMERA_SIOD)
+cam = OV7670(
+    bus,
+    data_pins=board.CAMERA_DATA,
+    clock=board.CAMERA_PCLK,
+    vsync=board.CAMERA_VSYNC,
+    href=board.CAMERA_HREF,
+    mclk=board.CAMERA_XCLK,
+    mclk_frequency=20_000_000,
+)
+
+cam.size = OV7670_SIZE_DIV2
+cam.flip_x = False
+cam.flip_y = True
+pid = cam.product_id
+ver = cam.product_version
+print(f"Detected pid={pid:x} ver={ver:x}")
+# cam.test_pattern = OV7670_TEST_PATTERN_COLOR_BAR
+
+g = displayio.Group(scale=1)
+bitmap = displayio.Bitmap(320, 240, 65536)
+tg = displayio.TileGrid(
+    bitmap,
+    pixel_shader=displayio.ColorConverter(
+        input_colorspace=displayio.Colorspace.RGB565_SWAPPED
+    ),
+)
+g.append(tg)
+display.show(g)
+
+t0 = time.monotonic_ns()
+display.auto_refresh = False
+while True:
+    cam.capture(bitmap)
+    bitmap.dirty()
+    display.refresh(minimum_frames_per_second=0)
+    t1 = time.monotonic_ns()
+    print("fps", 1e9 / (t1 - t0))
+    t0 = t1
+
+cam.deinit()

--- a/examples/ov7670_displayio_pico_st7789_2in.py
+++ b/examples/ov7670_displayio_pico_st7789_2in.py
@@ -45,7 +45,16 @@ with digitalio.DigitalInOut(board.GP10) as reset:
 # Set up the camera (you must customize this for your board!)
 cam = OV7670(
     bus,
-    data0=board.GP12,  # [16]     [org]
+    data_pins=[
+        board.GP12,
+        board.GP13,
+        board.GP14,
+        board.GP15,
+        board.GP16,
+        board.GP17,
+        board.GP18,
+        board.GP19,
+    ],  # [16]     [org] etc
     clock=board.GP11,  # [15]     [blk]
     vsync=board.GP7,  # [10]     [brn]
     href=board.GP21,  # [27/o14] [red]

--- a/examples/ov7670_displayio_pico_st7789_2in.py
+++ b/examples/ov7670_displayio_pico_st7789_2in.py
@@ -78,7 +78,7 @@ for size in range(OV7670_SIZE_DIV1, OV7670_SIZE_DIV16 + 1):
     if cam.height > height:
         continue
     try:
-        bitmap = Bitmap(cam.width, cam.height, 65535)
+        bitmap = Bitmap(cam.width, cam.height, 65536)
         break
     except MemoryError:
         continue


### PR DESCRIPTION
See https://github.com/adafruit/circuitpython/pull/4880 —instead of "data0", pass a list of "data_pins".  This supports non-sequential data pins on ESP32S2.